### PR TITLE
VSCode Keybindings

### DIFF
--- a/vscode/keybindings.json
+++ b/vscode/keybindings.json
@@ -1,0 +1,13 @@
+// Place your key bindings in this file to override the defaultsauto[]
+[
+    {
+  "key": "ctrl+k",
+  "command": "workbench.action.focusActiveEditorGroup",
+  "when": "terminalFocus"
+},
+{
+  "key": "ctrl+j",
+  "command": "workbench.action.terminal.focus",
+  "when": "!terminalFocus"
+}
+]


### PR DESCRIPTION
Add keybindings to switch from terminal to focus group back and forth